### PR TITLE
Support using custom DNS servers instead of picking from the host

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -67,6 +67,10 @@ properties:
   garden.dropsonde.destination:
     description: "A URL that points at the Metron agent to which metrics are forwarded. By default, it matches with the default of Metron."
 
+  garden.dns_servers:
+    description: Override DNS servers to be used in containers; defaults to the same as the host
+    default: []
+
   garden.insecure_docker_registry_list:
     description: "A list of IP:PORT tuples that we allow pulling docker images from using self-signed certificates."
     default: []

--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -128,6 +128,9 @@ case $1 in
     <% p("garden.insecure_docker_registry_list").each do |url| %> \
       -insecureDockerRegistry=<%= url %> \
     <% end %> \
+    <% p("garden.dns_servers").each do |server| %> \
+      -dnsServer=<%= server %> \
+    <% end %> \
       1>>$LOG_DIR/garden.stdout.log \
       2>>$LOG_DIR/garden.stderr.log
 


### PR DESCRIPTION
This implements a `garden.dns_servers` property which will force the container to use those DNS servers rather than guessing from the host's `resolv.conf`.

See also cloudfoundry-incubator/garden-linux#60.

This depends on ~~cloudfoundry-incubator/garden#45~~ and cloudfoundry-incubator/guardian#17.

Edit: This doesn't _actually_ depend on changing `garden`. Closed that one.