### PR TITLE
Shared mount

### DIFF
--- a/jobs/garden/monit
+++ b/jobs/garden/monit
@@ -1,6 +1,6 @@
 check process garden
   with pidfile /var/vcap/sys/run/garden/garden.pid
-  start program "/bin/sh -c '/var/vcap/jobs/garden/bin/share_mount && /usr/bin/unshare -m /var/vcap/jobs/garden/bin/garden_ctl start'"
+  start program "/bin/sh -c '/var/vcap/jobs/garden/bin/share_mounts && /usr/bin/unshare -m /var/vcap/jobs/garden/bin/garden_ctl start'"
   stop program "/var/vcap/jobs/garden/bin/garden_ctl stop"
 <% if p("garden.listen_network") == "unix" %>
   if failed unixsocket <%= p("garden.listen_address") %>

--- a/jobs/garden/monit
+++ b/jobs/garden/monit
@@ -1,6 +1,6 @@
 check process garden
   with pidfile /var/vcap/sys/run/garden/garden.pid
-  start program "/usr/bin/unshare -m /var/vcap/jobs/garden/bin/garden_ctl start"
+  start program "/bin/sh -c '/var/vcap/jobs/garden/bin/share_mount && /usr/bin/unshare -m /var/vcap/jobs/garden/bin/garden_ctl start'"
   stop program "/var/vcap/jobs/garden/bin/garden_ctl stop"
 <% if p("garden.listen_network") == "unix" %>
   if failed unixsocket <%= p("garden.listen_address") %>

--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -3,7 +3,7 @@ name: garden
 
 templates:
   garden_ctl.erb: bin/garden_ctl
-  share_mount.erb: bin/share_mount
+  share_mounts.erb: bin/share_mounts
 
 packages:
   - guardian
@@ -89,3 +89,7 @@ properties:
 
   garden.network_plugin_extra_args:
     description: "An array of additional arguments which will be passed to the network plugin binary"
+
+  garden.shared_mounts:
+    description: "A list of mount points to share into the garden mount namespace"
+    default: []

--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -3,6 +3,7 @@ name: garden
 
 templates:
   garden_ctl.erb: bin/garden_ctl
+  share_mount.erb: bin/share_mount
 
 packages:
   - guardian

--- a/jobs/garden/templates/share_mount.erb
+++ b/jobs/garden/templates/share_mount.erb
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+set -u
+
+shared_dir="/var/vcap/data/guardian/shared"
+
+mkdir -p $shared_dir
+
+mount --bind $shared_dir $shared_dir
+mount --make-shared $shared_dir

--- a/jobs/garden/templates/share_mounts.erb
+++ b/jobs/garden/templates/share_mounts.erb
@@ -3,9 +3,10 @@
 set -e
 set -u
 
-shared_dir="/var/vcap/data/guardian/shared"
+<% p("garden.shared_mounts").each do |shared_dir| %>
+shared_dir="<%= shared_dir.to_s %>"
 
 mkdir -p $shared_dir
-
 mount --bind $shared_dir $shared_dir
 mount --make-shared $shared_dir
+<% end %>


### PR DESCRIPTION
The recent changes to guardian to unshare the mount namespace have caused [failures in the ducati acceptance tests][1]. One way to resolve the issue is to explicitly create a bind mount for our data location and share that mount point so it propagates into the guardian namespace.

We have made the list of directories configurable so we can preserve the current paths.

/cc @rosenhouse

[1]: https://www.pivotaltracker.com/story/show/116097425