### PR TITLE
Surface bosh config for -maxContainers flag

### DIFF
--- a/jobs/garden/spec
+++ b/jobs/garden/spec
@@ -93,3 +93,6 @@ properties:
   garden.shared_mounts:
     description: "A list of mount points to share into the garden mount namespace"
     default: []
+
+  garden.max_containers:
+    description: "Maximum container capacity to advertise. It is not recommended to set this larger than 250."

--- a/jobs/garden/templates/garden_ctl.erb
+++ b/jobs/garden/templates/garden_ctl.erb
@@ -108,6 +108,9 @@ case $1 in
       -rootfs=<%= p("garden.default_container_rootfs") %> \
       -containerGraceTime=<%= p("garden.default_container_grace_time") %> \
       -graphCleanupThresholdMB=<%= p("garden.graph_cleanup_threshold_in_mb") %> \
+    <% if_p("garden.max_containers") do |max_containers| %> \
+      -maxContainers=<%= max_containers %> \
+    <% end %> \
     <% if_p("garden.network_plugin") do |plugin| %> \
       -networkPlugin=<%= plugin %> \
       <% if_p("garden.network_plugin_extra_args") do |args| %> \


### PR DESCRIPTION
The guardian submodule that includes https://github.com/cloudfoundry-incubator/guardian/pull/22 should be bumped at the same time.

[#116805113]